### PR TITLE
Refactor item cloning to preserve container predicates

### DIFF
--- a/index.html
+++ b/index.html
@@ -330,7 +330,7 @@
                     id: this.id,
                     name: this.name,
                     kind: this.kind,
-                    equipSlots: Array.isArray(this.equipSlots) ? this.equipSlots.slice() : [],
+                    equipSlots: Array.isArray(this.equipSlots) ? this.equipSlots.slice() : this.equipSlots,
                     handsRequired: this.handsRequired,
                     dims: this.dims ? { ...this.dims } : undefined,
                     mass: this.mass,
@@ -342,9 +342,6 @@
 
                 if (this.container) {
                     copy.container = { ...this.container };
-                    if (typeof this.container.accepts === "function") {
-                        copy.container.accepts = this.container.accepts;
-                    }
                 }
 
                 const cloned = new Item(copy);

--- a/index.html
+++ b/index.html
@@ -325,7 +325,36 @@
                 // Runtime state for containers (contents as stacks)
                 if (this.container) this.contents = [];
             }
-            clone() { return new Item(JSON.parse(JSON.stringify(this))); }
+            clone() {
+                const copy = {
+                    id: this.id,
+                    name: this.name,
+                    kind: this.kind,
+                    equipSlots: Array.isArray(this.equipSlots) ? this.equipSlots.slice() : [],
+                    handsRequired: this.handsRequired,
+                    dims: this.dims ? { ...this.dims } : undefined,
+                    mass: this.mass,
+                    stackable: this.stackable,
+                    maxStack: this.maxStack,
+                    lightRadius: this.lightRadius,
+                    container: null,
+                };
+
+                if (this.container) {
+                    copy.container = { ...this.container };
+                    if (typeof this.container.accepts === "function") {
+                        copy.container.accepts = this.container.accepts;
+                    }
+                }
+
+                const cloned = new Item(copy);
+
+                if (Array.isArray(this.contents)) {
+                    cloned.contents = this.contents.slice();
+                }
+
+                return cloned;
+            }
             canEquipTo(slot) { return this.equipSlots.includes(slot); }
             volumeLPerUnit() { return dimsVolumeL(this.dims); }
             longestCm() { return dimsLongest(this.dims); }


### PR DESCRIPTION
## Summary
- refactor Item.clone to use explicit object copying
- preserve container.accepts functions and shallow-copy nested arrays/objects during item cloning

## Testing
- node - <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68e5543d7cb4832bb30be17144adf382